### PR TITLE
Fix the search bar

### DIFF
--- a/v2ex.css
+++ b/v2ex.css
@@ -117,7 +117,7 @@ a:active {
   right: 240px;
   background: url("//dn-startplay.qbox.me/v2ex-material-theme/wallet_giftcard_hl.svg") no-repeat center;
 }
-@media only screen and (max-width: 1260px) {
+@media only screen and (max-width: 1400px) {
   #Top form div {
     width: 276px!important;
   }

--- a/v2ex.less
+++ b/v2ex.less
@@ -138,7 +138,7 @@ a:link, a:visited, a:active {
 	background: url("@{icon-url}/wallet_giftcard_hl.svg") no-repeat center;
 }
 
-@media only screen and (max-width : 1260px) {
+@media only screen and (max-width : 1400px) {
 	#Top{
 		form div{
 			width: 276px!important;


### PR DESCRIPTION
当窗口宽度在 1260px 至 1350px 之间时，V2EX LOGO 与搜索框重叠。因此将缩小搜索框的上限宽度放大至 1400px。

否则，亦可将 .content max-width 缩小至 1000px。
